### PR TITLE
Use python3 in App Runner build commands

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -4,8 +4,8 @@ build:
   commands:
     build:
       - echo "Starting build process..."
-      - python -m pip install --upgrade pip
-      - pip install -r requirements.txt
+      - python3 -m pip install --upgrade pip
+      - python3 -m pip install -r requirements.txt
       - echo "Build completed successfully"
   env:
     - name: FLASK_ENV

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -2,10 +2,11 @@ version: 1.0
 runtime: python3
 build:
   commands:
-    - echo "Starting build process..."
-    - python3 -m pip install --upgrade pip
-    - python3 -m pip install -r requirements.txt
-    - echo "Build completed successfully"
+    build:
+      - echo "Starting build process..."
+      - python3 -m pip install --upgrade pip
+      - python3 -m pip install -r requirements.txt
+      - echo "Build completed successfully"
   env:
     - name: FLASK_ENV
       value: production

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -2,11 +2,10 @@ version: 1.0
 runtime: python3
 build:
   commands:
-    build:
-      - echo "Starting build process..."
-      - python3 -m pip install --upgrade pip
-      - python3 -m pip install -r requirements.txt
-      - echo "Build completed successfully"
+    - echo "Starting build process..."
+    - python3 -m pip install --upgrade pip
+    - python3 -m pip install -r requirements.txt
+    - echo "Build completed successfully"
   env:
     - name: FLASK_ENV
       value: production

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-runtime: python3
+runtime: python311
 build:
   commands:
     build:
@@ -11,7 +11,7 @@ build:
     - name: FLASK_ENV
       value: production
 run:
-  runtime-version: 3.11
+  runtime-version: "3.11"
   command: gunicorn --bind 0.0.0.0:8080 --workers 2 --timeout 300 app:app
   network:
     port: 8080

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -3,21 +3,13 @@ runtime: python311
 build:
   commands:
     build:
-      - echo "Starting build process..."
       - pip3 install --upgrade pip
       - pip3 install -r requirements.txt
-      - echo "Build completed successfully"
-  env:
-    - name: FLASK_ENV
-      value: production
 run:
   runtime-version: "3.11"
-  command: gunicorn --bind 0.0.0.0:8080 --workers 2 --timeout 300 app:app
+  command: python3 -m gunicorn --bind 0.0.0.0:8080 --workers 2 app:app
   network:
     port: 8080
-    env: PORT
   env:
-    - name: PORT
-      value: "8080"
-    - name: FLASK_ENV
-      value: production
+    - name: PYTHONPATH
+      value: /opt/app

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -5,7 +5,7 @@ build:
     build:
       - echo "Starting build process..."
       - pip3 install --upgrade pip
-      - pip3 -m pip install -r requirements.txt
+      - pip3 install -r requirements.txt
       - echo "Build completed successfully"
   env:
     - name: FLASK_ENV

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -4,14 +4,14 @@ build:
   commands:
     build:
       - echo "Starting build process..."
-      - python3 -m pip install --upgrade pip
-      - python3 -m pip install -r requirements.txt
+      - pip3 install --upgrade pip
+      - pip3 -m pip install -r requirements.txt
       - echo "Build completed successfully"
   env:
     - name: FLASK_ENV
       value: production
 run:
-  runtime-version: 3.8
+  runtime-version: 3.11
   command: gunicorn --bind 0.0.0.0:8080 --workers 2 --timeout 300 app:app
   network:
     port: 8080


### PR DESCRIPTION
## Summary
- use python3 -m pip in apprunner.yaml so build env works on Amazon Linux

## Testing
- `python - <<'PY'
import yaml
with open('apprunner.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_b_688e0c04edfc8331a939fb132f38fa17